### PR TITLE
3//12 is a Rational, not 0.25 (a Float64)

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,9 +143,9 @@ end</code>
             </tr>
 
             <tr>
-              <td>Fractional division</td>
+              <td>Division</td>
 
-              <td><code>3//12 == 0.25</code></td>
+              <td><code>3/12 == 0.25</code></td>
             </tr>
 
             <tr>


### PR DESCRIPTION
The current "Fractional Division, 3//12 == 0.25" is misleading. In Julia 3//12 is a Rational number. Evaluating 3//12 produces 1//4, a Rational{Int64}), not 0.25, a Float64. 

I suggest switching this to "Division, 3/12 == 0.25", because 3/12 evaluates to the Float64 value 0.25.

To illustrate Rationals, perhaps it would be good to have an additional entry "Rational numbers, 3//12 == 1//4"